### PR TITLE
Add support for the adbc_ingest comand for csv files

### DIFF
--- a/src/c/statement.cc
+++ b/src/c/statement.cc
@@ -1099,7 +1099,7 @@ AdbcStatusCode NetezzaStatement::CreateBulkTable(
       // Nothing to do
       break;
     case IngestMode::kReplace: {
-      std::string drop = "DROP TABLE IF EXISTS " + *escaped_table;
+      std::string drop = "DROP TABLE " + *escaped_table + " IF EXISTS";
       PGresult* result = PQexecParams(conn, drop.c_str(), /*nParams=*/0,
                                       /*paramTypes=*/nullptr, /*paramValues=*/nullptr,
                                       /*paramLengths=*/nullptr, /*paramFormats=*/nullptr,

--- a/src/c/statement.h
+++ b/src/c/statement.h
@@ -32,6 +32,8 @@
 
 #define ADBC_NETEZZA_OPTION_BATCH_SIZE_HINT_BYTES \
   "adbc.netezza.batch_size_hint_bytes"
+#define ADBC_INGEST_OPTION_TARGET_FILE_PATH \
+  "adbc.netezza.reader_file_path"
 
 namespace adbcpq {
 class NetezzaConnection;
@@ -163,6 +165,7 @@ class NetezzaStatement {
     std::string target;
     IngestMode mode = IngestMode::kCreate;
     bool temporary = false;
+    std::string target_file_path;
   } ingest_;
 
   TupleReader reader_;

--- a/src/python/adbc_driver_netezza/dbapi.py
+++ b/src/python/adbc_driver_netezza/dbapi.py
@@ -19,7 +19,27 @@
 DBAPI 2.0-compatible facade for the ADBC libpq driver.
 """
 
-import typing
+from adbc_driver_manager.dbapi import Cursor, Connection
+
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+try:
+    import pyarrow
+except ImportError as e:
+    raise ImportError("PyArrow is required for the DBAPI-compatible interface") from e
+
+try:
+    import pyarrow.dataset
+except ImportError:
+    _pya_dataset = ()
+    _pya_scanner = ()
+else:
+    _pya_dataset = (pyarrow.dataset.Dataset,)
+    _pya_scanner = (pyarrow.dataset.Scanner,)
+
+from adbc_driver_manager import _lib, _reader
+from adbc_driver_manager._lib import _blocking_call
+
 
 import adbc_driver_manager
 import adbc_driver_manager.dbapi
@@ -90,16 +110,18 @@ NUMBER = adbc_driver_manager.dbapi.NUMBER
 DATETIME = adbc_driver_manager.dbapi.DATETIME
 ROWID = adbc_driver_manager.dbapi.ROWID
 
+INGEST_OPTION_TARGET_FILE_PATH: str
+ADBC_NETEZZA_OPTION_FILE_PATH = "adbc.netezza.reader_file_path"
 # ----------------------------------------------------------
 # Functions
 
 
 def connect(
     uri: str,
-    db_kwargs: typing.Optional[typing.Dict[str, str]] = None,
-    conn_kwargs: typing.Optional[typing.Dict[str, str]] = None,
+    db_kwargs: Optional[Dict[str, str]] = None,
+    conn_kwargs: Optional[Dict[str, str]] = None,
     **kwargs
-) -> "Connection":
+) -> "NetezzaConnection":
     """
     Connect to Netezza via ADBC.
 
@@ -120,7 +142,7 @@ def connect(
     try:
         db = adbc_driver_netezza.connect(uri)
         conn = adbc_driver_manager.AdbcConnection(db)
-        return adbc_driver_manager.dbapi.Connection(db, conn, **kwargs)
+        return NetezzaConnection(db, conn, **kwargs)
     except Exception:
         if conn:
             conn.close()
@@ -128,9 +150,142 @@ def connect(
             db.close()
         raise
 
-
 # ----------------------------------------------------------
 # Classes
 
-Connection = adbc_driver_manager.dbapi.Connection
-Cursor = adbc_driver_manager.dbapi.Cursor
+class NetezzaConnection(Connection):
+    def cursor(self) -> "NetezzaCursor":
+        """Create a new cursor for querying the database."""
+        return NetezzaCursor(self)
+
+class NetezzaCursor(Cursor):
+    def adbc_ingest(
+        self,
+        table_name: str,
+        data: Union[pyarrow.RecordBatch, pyarrow.Table, pyarrow.RecordBatchReader],
+        mode: Literal["append", "create", "replace", "create_append"] = "create",
+        *,
+        catalog_name: Optional[str] = None,
+        db_schema_name: Optional[str] = None,
+        temporary: bool = False,
+        reader_file_path: str = None
+    ) -> int:
+        """Ingest CSV data into a database table.
+
+        For the Netezza Driver this function is used to ingest csv data into
+        a database table
+
+        Parameters
+        ----------
+        table_name
+            The table to insert into.
+        data
+            The Arrow data to for the file to insert . 
+            This can be a pyarrow RecordBatch, Table or RecordBatchReader, or any Arrow-compatible data that implements
+            the Arrow PyCapsule Protocol (i.e. has an ``__arrow_c_array__``
+            or ``__arrow_c_stream__`` method).
+        mode
+            How to deal with existing data:
+
+            - 'append': append to a table (error if table does not exist)
+            - 'create': create a table and insert (error if table exists)
+            - 'create_append': create a table (if not exists) and insert
+            - 'replace': drop existing table (if any), then same as 'create'
+        catalog_name
+            If given, the catalog to create/locate the table in.
+            **This API is EXPERIMENTAL.**
+        db_schema_name
+            If given, the schema to create/locate the table in.
+            **This API is EXPERIMENTAL.**
+        temporary
+            Whether to ingest to a temporary table or not.  Most drivers will
+            not support setting this along with catalog_name and/or
+            db_schema_name.
+            **This API is EXPERIMENTAL.**
+        reader_file_path
+            Netezza specific parameter for adbc_ingest to provide the path
+            of the file tryng to ingest
+            **This API is EXPERIMENTAL.**
+
+        Returns
+        -------
+        int
+            The number of rows inserted, or -1 if the driver cannot
+            provide this information.
+
+        Notes
+        -----
+        This is an extension and not part of the DBAPI standard.
+
+        """
+        if mode == "append":
+            c_mode = _lib.INGEST_OPTION_MODE_APPEND
+        elif mode == "create":
+            c_mode = _lib.INGEST_OPTION_MODE_CREATE
+        elif mode == "create_append":
+            c_mode = _lib.INGEST_OPTION_MODE_CREATE_APPEND
+        elif mode == "replace":
+            c_mode = _lib.INGEST_OPTION_MODE_REPLACE
+        else:
+            raise ValueError(f"Invalid value for 'mode': {mode}")
+
+        options = {
+            _lib.INGEST_OPTION_TARGET_TABLE: table_name,
+            _lib.INGEST_OPTION_MODE: c_mode,
+            "adbc.netezza.reader_file_path" : reader_file_path
+        }
+        if catalog_name is not None:
+            options[
+                adbc_driver_manager.StatementOptions.INGEST_TARGET_CATALOG.value
+            ] = catalog_name
+        if db_schema_name is not None:
+            options[
+                adbc_driver_manager.StatementOptions.INGEST_TARGET_DB_SCHEMA.value
+            ] = db_schema_name
+
+        self._stmt.set_options(**options)
+
+        if temporary:
+            self._stmt.set_options(
+                **{
+                    adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "true",
+                }
+            )
+        else:
+            # Need to explicitly clear it, but not all drivers support this
+            options = {
+                adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "false",
+            }
+            try:
+                self._stmt.set_options(**options)
+            except NotSupportedError:
+                pass
+
+        if hasattr(data, "__arrow_c_array__"):
+            self._stmt.bind(data)
+        elif hasattr(data, "__arrow_c_stream__"):
+            self._stmt.bind_stream(data)
+        elif isinstance(data, pyarrow.RecordBatch):
+            array = _lib.ArrowArrayHandle()
+            schema = _lib.ArrowSchemaHandle()
+            data._export_to_c(array.address, schema.address)
+            self._stmt.bind(array, schema)
+        else:
+            if isinstance(data, pyarrow.Table):
+                data = data.to_reader()
+            elif isinstance(data, pyarrow.dataset.Dataset):
+                data = data.scanner().to_reader()
+            elif isinstance(data, pyarrow.dataset.Scanner):
+                data = data.to_reader()
+            elif not hasattr(data, "_export_to_c"):
+                data = pyarrow.Table.from_batches(data)
+                data = data.to_reader()
+            handle = _lib.ArrowArrayStreamHandle()
+            data._export_to_c(handle.address)
+            self._stmt.bind_stream(handle)
+
+        self._last_query = None
+        return _blocking_call(self._stmt.execute_update, (), {}, self._stmt.cancel)
+
+Connection = NetezzaConnection
+Cursor = NetezzaCursor


### PR DESCRIPTION
Problem:
The adbc_ingest command for the cursor object for adbc-netezza-driver was not supported previously

Solution:
Added the support for the adbc_ingest command for adbc-driver-netezza. We need to provide an additional file path along with the reader object for it to work.

Testing:

```
import adbc_driver_netezza.dbapi
import tempfile
uri = "netezza://admin:password@host:5480/SYSTEM"
conn = adbc_driver_netezza.dbapi.connect(uri)

tempdir = tempfile.TemporaryDirectory(
    prefix="adbc-docs-",
    ignore_cleanup_errors=True,
)
root = Path(tempdir.name)
table = pyarrow.table(
    [
        [1, 1, 2],
        ["foo", "bar", "baz"],
    ],
    names=["ints", "strs"],
)
csv_file = root / "example.csv"
pyarrow.csv.write_csv(table, csv_file)
with conn.cursor() as cur:
    reader = pyarrow.csv.open_csv(csv_file)
    cur.adbc_ingest("csvtable", reader ,mode="create", reader_file_path=str(csv_file))
```

Output:
```
[root@ayush-nz1 ingestcsv_adbc_pr]# python3 test.py 
<adbc_driver_netezza.dbapi.NetezzaConnection object at 0x7f6545244bd0>
NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
```
```
SYSTEM.ADMIN(ADMIN)=> \d
         List of relations
 Schema |   Name   | Type  | Owner 
--------+----------+-------+-------
 ADMIN  | CSVTABLE | TABLE | ADMIN
(1 row)

SYSTEM.ADMIN(ADMIN)=> select * from csvtable;
 INTS | STRS  
------+-------
    2 | "baz"
    1 | "foo"
    1 | "bar"
(3 rows)

SYSTEM.ADMIN(ADMIN)=> 
```