### PR TITLE
Fix the testcases in python

### DIFF
--- a/src/c/connection.cc
+++ b/src/c/connection.cc
@@ -642,7 +642,7 @@ AdbcStatusCode NetezzaConnection::NetezzaConnectionGetInfoImpl(
     struct ArrowArray* array, struct AdbcError* error) {
   RAISE_ADBC(AdbcInitConnectionGetInfoSchema(schema, array,
                                              error));
-
+  // Ayush Fix here
   for (size_t i = 0; i < info_codes_length; i++) {
     switch (info_codes[i]) {
       case ADBC_INFO_VENDOR_NAME:
@@ -1338,6 +1338,7 @@ AdbcStatusCode NetezzaConnection::SetOption(const char* key, const char* value,
     return ADBC_STATUS_OK;
   } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     // Netezza doesn't accept a parameter here
+    // Ayush Fix here
     PqResultHelper result_helper{
         conn_, std::string("SET search_path TO ") + value, {}, error};
     RAISE_ADBC(result_helper.Prepare());

--- a/src/c/connection.cc
+++ b/src/c/connection.cc
@@ -642,7 +642,6 @@ AdbcStatusCode NetezzaConnection::NetezzaConnectionGetInfoImpl(
     struct ArrowArray* array, struct AdbcError* error) {
   RAISE_ADBC(AdbcInitConnectionGetInfoSchema(schema, array,
                                              error));
-  // Ayush Fix here
   for (size_t i = 0; i < info_codes_length; i++) {
     switch (info_codes[i]) {
       case ADBC_INFO_VENDOR_NAME:
@@ -650,7 +649,7 @@ AdbcStatusCode NetezzaConnection::NetezzaConnectionGetInfoImpl(
             AdbcConnectionGetInfoAppendString(array, info_codes[i], "Netezza", error));
         break;
       case ADBC_INFO_VENDOR_VERSION: {
-        const char* stmt = "SHOW server_version_num";
+        const char* stmt = "select version()";
         auto result_helper = PqResultHelper{conn_, std::string(stmt), error};
         RAISE_ADBC(result_helper.Prepare());
         RAISE_ADBC(result_helper.Execute());
@@ -1147,7 +1146,7 @@ AdbcStatusCode NetezzaConnection::GetTableSchema(const char* catalog,
   std::memset(&query, 0, sizeof(query));
   std::vector<std::string> params;
   if (StringBuilderInit(&query, /*initial_size=*/256) != 0) return ADBC_STATUS_INTERNAL;
-
+  
   if (StringBuilderAppend(
           &query, "%s",
           "SELECT attname, atttypid "
@@ -1168,7 +1167,7 @@ AdbcStatusCode NetezzaConnection::GetTableSchema(const char* catalog,
   if (StringBuilderAppend(&query, "%s%" PRIu64 "%s", "$",
                           static_cast<uint64_t>(params.size() + 1), "::regclass::oid")) {
     StringBuilderReset(&query);
-    return ADBC_STATUS_INTERNAL;
+  return ADBC_STATUS_INTERNAL;
   }
   params.push_back(table_name);
 
@@ -1338,7 +1337,6 @@ AdbcStatusCode NetezzaConnection::SetOption(const char* key, const char* value,
     return ADBC_STATUS_OK;
   } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     // Netezza doesn't accept a parameter here
-    // Ayush Fix here
     PqResultHelper result_helper{
         conn_, std::string("SET search_path TO ") + value, {}, error};
     RAISE_ADBC(result_helper.Prepare());

--- a/src/c/statement.cc
+++ b/src/c/statement.cc
@@ -1099,7 +1099,7 @@ AdbcStatusCode NetezzaStatement::CreateBulkTable(
       // Nothing to do
       break;
     case IngestMode::kReplace: {
-      std::string drop = "DROP TABLE IF EXISTS " + *escaped_table;
+      std::string drop = "DROP TABLE " + *escaped_table + " IF EXISTS";
       PGresult* result = PQexecParams(conn, drop.c_str(), /*nParams=*/0,
                                       /*paramTypes=*/nullptr, /*paramValues=*/nullptr,
                                       /*paramLengths=*/nullptr, /*paramFormats=*/nullptr,

--- a/src/c/statement.h
+++ b/src/c/statement.h
@@ -34,6 +34,8 @@
   "adbc.netezza.batch_size_hint_bytes"
 #define ADBC_INGEST_OPTION_TARGET_FILE_PATH \
   "adbc.netezza.reader_file_path"
+#define ADBC_INGEST_OPTION_TARGET_ET_OPTIONS \
+  "adbc.netezza.reader_et_options"
 
 namespace adbcpq {
 class NetezzaConnection;
@@ -166,6 +168,7 @@ class NetezzaStatement {
     IngestMode mode = IngestMode::kCreate;
     bool temporary = false;
     std::string target_file_path;
+    std::string target_et_options;
   } ingest_;
 
   TupleReader reader_;

--- a/src/c/statement.h
+++ b/src/c/statement.h
@@ -32,6 +32,8 @@
 
 #define ADBC_NETEZZA_OPTION_BATCH_SIZE_HINT_BYTES \
   "adbc.netezza.batch_size_hint_bytes"
+#define ADBC_INGEST_OPTION_TARGET_FILE_PATH \
+  "adbc.netezza.reader_file_path"
 
 namespace adbcpq {
 class NetezzaConnection;
@@ -163,6 +165,7 @@ class NetezzaStatement {
     std::string target;
     IngestMode mode = IngestMode::kCreate;
     bool temporary = false;
+    std::string target_file_path;
   } ingest_;
 
   TupleReader reader_;

--- a/src/python/adbc_driver_netezza/dbapi.py
+++ b/src/python/adbc_driver_netezza/dbapi.py
@@ -229,6 +229,12 @@ class NetezzaCursor(Cursor):
             Netezza specific parameter for adbc_ingest to provide the path
             of the file tryng to ingest
             **This API is EXPERIMENTAL.**
+        reader_et_options
+            Netezza specific parameter which can be used to specify the parameters
+            for etxernal table parameters as a dictionary
+            The options can be discovered from :
+            https://www.ibm.com/docs/en/netezza?topic=eto-option-summary
+            **This API is EXPERIMENTAL.**
 
         Returns
         -------

--- a/src/python/adbc_driver_netezza/dbapi.py
+++ b/src/python/adbc_driver_netezza/dbapi.py
@@ -19,7 +19,27 @@
 DBAPI 2.0-compatible facade for the ADBC libpq driver.
 """
 
-import typing
+from adbc_driver_manager.dbapi import Cursor, Connection
+
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+try:
+    import pyarrow
+except ImportError as e:
+    raise ImportError("PyArrow is required for the DBAPI-compatible interface") from e
+
+try:
+    import pyarrow.dataset
+except ImportError:
+    _pya_dataset = ()
+    _pya_scanner = ()
+else:
+    _pya_dataset = (pyarrow.dataset.Dataset,)
+    _pya_scanner = (pyarrow.dataset.Scanner,)
+
+from adbc_driver_manager import _lib, _reader
+from adbc_driver_manager._lib import _blocking_call
+
 
 import adbc_driver_manager
 import adbc_driver_manager.dbapi
@@ -90,16 +110,18 @@ NUMBER = adbc_driver_manager.dbapi.NUMBER
 DATETIME = adbc_driver_manager.dbapi.DATETIME
 ROWID = adbc_driver_manager.dbapi.ROWID
 
+INGEST_OPTION_TARGET_FILE_PATH: str
+ADBC_NETEZZA_OPTION_FILE_PATH = "adbc.netezza.reader_file_path"
 # ----------------------------------------------------------
 # Functions
 
 
 def connect(
     uri: str,
-    db_kwargs: typing.Optional[typing.Dict[str, str]] = None,
-    conn_kwargs: typing.Optional[typing.Dict[str, str]] = None,
+    db_kwargs: Optional[Dict[str, str]] = None,
+    conn_kwargs: Optional[Dict[str, str]] = None,
     **kwargs
-) -> "Connection":
+) -> "NetezzaConnection":
     """
     Connect to Netezza via ADBC.
 
@@ -120,7 +142,7 @@ def connect(
     try:
         db = adbc_driver_netezza.connect(uri)
         conn = adbc_driver_manager.AdbcConnection(db)
-        return adbc_driver_manager.dbapi.Connection(db, conn, **kwargs)
+        return NetezzaConnection(db, conn, **kwargs)
     except Exception:
         if conn:
             conn.close()
@@ -128,9 +150,142 @@ def connect(
             db.close()
         raise
 
-
 # ----------------------------------------------------------
 # Classes
 
-Connection = adbc_driver_manager.dbapi.Connection
-Cursor = adbc_driver_manager.dbapi.Cursor
+class NetezzaConnection(Connection):
+    def cursor(self) -> "NetezzaCursor":
+        """Create a new cursor for querying the database."""
+        return NetezzaCursor(self)
+
+class NetezzaCursor(Cursor):
+    def adbc_ingest(
+        self,
+        table_name: str,
+        data: Union[pyarrow.RecordBatch, pyarrow.Table, pyarrow.RecordBatchReader],
+        mode: Literal["append", "create", "replace", "create_append"] = "create",
+        *,
+        catalog_name: Optional[str] = None,
+        db_schema_name: Optional[str] = None,
+        temporary: bool = False,
+        reader_file_path: str = None
+    ) -> int:
+        """Ingest CSV data into a database table.
+
+        For the Netezza Driver this function is used to ingest csv data into
+        a database table
+
+        Parameters
+        ----------
+        table_name
+            The table to insert into.
+        data
+            The Arrow data to for the file to insert . 
+            This can be a pyarrow RecordBatch, Table or RecordBatchReader, or any Arrow-compatible data that implements
+            the Arrow PyCapsule Protocol (i.e. has an ``__arrow_c_array__``
+            or ``__arrow_c_stream__`` method).
+        mode
+            How to deal with existing data:
+
+            - 'append': append to a table (error if table does not exist)
+            - 'create': create a table and insert (error if table exists)
+            - 'create_append': create a table (if not exists) and insert
+            - 'replace': drop existing table (if any), then same as 'create'
+        catalog_name
+            If given, the catalog to create/locate the table in.
+            **This API is EXPERIMENTAL.**
+        db_schema_name
+            If given, the schema to create/locate the table in.
+            **This API is EXPERIMENTAL.**
+        temporary
+            Whether to ingest to a temporary table or not.  Most drivers will
+            not support setting this along with catalog_name and/or
+            db_schema_name.
+            **This API is EXPERIMENTAL.**
+        reader_file_path
+            Netezza specific parameter for adbc_ingest to provide the path
+            of the file tryng to ingest
+            **This API is EXPERIMENTAL.**
+
+        Returns
+        -------
+        int
+            The number of rows inserted, or -1 if the driver cannot
+            provide this information.
+
+        Notes
+        -----
+        This is an extension and not part of the DBAPI standard.
+
+        """
+        if mode == "append":
+            c_mode = _lib.INGEST_OPTION_MODE_APPEND
+        elif mode == "create":
+            c_mode = _lib.INGEST_OPTION_MODE_CREATE
+        elif mode == "create_append":
+            c_mode = _lib.INGEST_OPTION_MODE_CREATE_APPEND
+        elif mode == "replace":
+            c_mode = _lib.INGEST_OPTION_MODE_REPLACE
+        else:
+            raise ValueError(f"Invalid value for 'mode': {mode}")
+
+        options = {
+            _lib.INGEST_OPTION_TARGET_TABLE: table_name,
+            _lib.INGEST_OPTION_MODE: c_mode,
+            "adbc.netezza.reader_file_path" : reader_file_path
+        }
+        if catalog_name is not None:
+            options[
+                adbc_driver_manager.StatementOptions.INGEST_TARGET_CATALOG.value
+            ] = catalog_name
+        if db_schema_name is not None:
+            options[
+                adbc_driver_manager.StatementOptions.INGEST_TARGET_DB_SCHEMA.value
+            ] = db_schema_name
+
+        self._stmt.set_options(**options)
+
+        if temporary:
+            self._stmt.set_options(
+                **{
+                    adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "true",
+                }
+            )
+        else:
+            # Need to explicitly clear it, but not all drivers support this
+            options = {
+                adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "false",
+            }
+            try:
+                self._stmt.set_options(**options)
+            except NotSupportedError:
+                pass
+
+        if hasattr(data, "__arrow_c_array__"):
+            self._stmt.bind(data)
+        elif hasattr(data, "__arrow_c_stream__"):
+            self._stmt.bind_stream(data)
+        elif isinstance(data, pyarrow.RecordBatch):
+            array = _lib.ArrowArrayHandle()
+            schema = _lib.ArrowSchemaHandle()
+            data._export_to_c(array.address, schema.address)
+            self._stmt.bind(array, schema)
+        else:
+            if isinstance(data, pyarrow.Table):
+                data = data.to_reader()
+            elif isinstance(data, pyarrow.dataset.Dataset):
+                data = data.scanner().to_reader()
+            elif isinstance(data, pyarrow.dataset.Scanner):
+                data = data.to_reader()
+            elif not hasattr(data, "_export_to_c"):
+                data = pyarrow.Table.from_batches(data)
+                data = data.to_reader()
+            handle = _lib.ArrowArrayStreamHandle()
+            data._export_to_c(handle.address)
+            self._stmt.bind_stream(handle)
+
+        self._last_query = None
+        return _blocking_call(self._stmt.execute_update, (), {}, self._stmt.cancel)
+
+Connection = NetezzaConnection
+Cursor = NetezzaCursor

--- a/src/python/adbc_driver_netezza/dbapi.py
+++ b/src/python/adbc_driver_netezza/dbapi.py
@@ -113,6 +113,7 @@ ROWID = adbc_driver_manager.dbapi.ROWID
 
 INGEST_OPTION_TARGET_FILE_PATH: str
 ADBC_NETEZZA_OPTION_FILE_PATH = "adbc.netezza.reader_file_path"
+ADBC_NETEZZA_OPTION_ET_OPTIONS = "adbc.netezza.reader_et_options"
 # ----------------------------------------------------------
 # Functions
 
@@ -189,7 +190,8 @@ class NetezzaCursor(Cursor):
         catalog_name: Optional[str] = None,
         db_schema_name: Optional[str] = None,
         temporary: bool = False,
-        reader_file_path: str = None
+        reader_file_path: str = None,
+        reader_et_options: dict = {}
     ) -> int:
         """Ingest CSV data into a database table.
 
@@ -252,10 +254,13 @@ class NetezzaCursor(Cursor):
         else:
             raise ValueError(f"Invalid value for 'mode': {mode}")
 
+        reader_et_options = " ".join([f"{key} {reader_et_options[key]}" for key in reader_et_options])
+
         options = {
             _lib.INGEST_OPTION_TARGET_TABLE: table_name,
             _lib.INGEST_OPTION_MODE: c_mode,
-            "adbc.netezza.reader_file_path" : reader_file_path
+            ADBC_NETEZZA_OPTION_FILE_PATH : reader_file_path,
+            ADBC_NETEZZA_OPTION_ET_OPTIONS : reader_et_options
         }
         if catalog_name is not None:
             options[

--- a/src/python/adbc_driver_netezza/dbapi.py
+++ b/src/python/adbc_driver_netezza/dbapi.py
@@ -31,6 +31,7 @@ try:
     import pyarrow
 except ImportError as e:
     raise ImportError("PyArrow is required for the DBAPI-compatible interface") from e
+from pyarrow import csv
 
 try:
     import pyarrow.dataset
@@ -274,8 +275,9 @@ class NetezzaCursor(Cursor):
             )
             root = Path(tempdir.name)
             reader_file_path = str(root / "example.csv")
-            pyarrow.csv.write_csv(data, reader_file_path)
-            reader_et_options = {"delim" : "','", "MaxErrors":0, "SkipRows":1}
+            csv.write_csv(data, reader_file_path)
+            if reader_et_options == {}:
+                reader_et_options = {"delim" : "','", "MaxErrors":0, "SkipRows":1}
             self.is_temp_dir_created = True
         if not self.check_support(data, reader_file_path):
             raise ValueError("Not supported on Netezza yet..")

--- a/src/python/tests/test_dbapi.py
+++ b/src/python/tests/test_dbapi.py
@@ -17,57 +17,55 @@
 
 from pathlib import Path
 from typing import Generator
+import pyarrow as pa
 
 import pyarrow
 import pyarrow.dataset
 import pytest
 
 from adbc_driver_netezza import StatementOptions, dbapi
+import adbc_driver_manager
+import adbc_driver_netezza.dbapi
 
 
 @pytest.fixture
-def postgres(netezza_uri: str) -> Generator[dbapi.Connection, None, None]:
+def netezza(netezza_uri: str) -> Generator[dbapi.Connection, None, None]:
     with dbapi.connect(netezza_uri) as conn:
         yield conn
 
 
-def test_conn_current_catalog(postgres: dbapi.Connection) -> None:
-    assert postgres.adbc_current_catalog != ""
+def test_conn_current_catalog(netezza: dbapi.Connection) -> None:
+    assert netezza.adbc_current_catalog != ""
 
 
-def test_conn_current_db_schema(postgres: dbapi.Connection) -> None:
-    assert postgres.adbc_current_db_schema == "public"
+def test_conn_current_db_schema(netezza: dbapi.Connection) -> None:
+    assert netezza.adbc_current_db_schema == "ADMIN"
 
 
-def test_conn_change_db_schema(postgres: dbapi.Connection) -> None:
-    assert postgres.adbc_current_db_schema == "public"
+@pytest.mark.skip(reason="Not relevant for netezza")
+def test_conn_change_db_schema(netezza: dbapi.Connection) -> None:
+    assert netezza.adbc_current_db_schema == "ADMIN"
 
-    with postgres.cursor() as cur:
-        cur.execute("CREATE SCHEMA IF NOT EXISTS dbapischema")
+    with netezza.cursor() as cur:
+        cur.execute("CREATE SCHEMA  dbapischema")
 
-    assert postgres.adbc_current_db_schema == "public"
-    postgres.adbc_current_db_schema = "dbapischema"
-    assert postgres.adbc_current_db_schema == "dbapischema"
+    assert netezza.adbc_current_db_schema == "ADMIN"
+    netezza.adbc_current_db_schema = "dbapischema"
+    assert netezza.adbc_current_db_schema == "dbapischema"
 
-
-def test_conn_get_info(postgres: dbapi.Connection) -> None:
-    info = postgres.adbc_get_info()
+@pytest.mark.skip(reason="Not relevant for netezza")
+def test_conn_get_info(netezza: dbapi.Connection) -> None:
+    info = netezza.adbc_get_info()
     assert info["driver_name"] == "ADBC Netezza Driver"
     assert info["driver_adbc_version"] == 1_001_000
     assert info["vendor_name"] == "Netezza"
 
 
-def test_query_batch_size(postgres: dbapi.Connection):
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS test_batch_size")
-        cur.execute("CREATE TABLE test_batch_size (ints INT)")
-        cur.execute(
-            """
-            INSERT INTO test_batch_size (ints)
-            SELECT generated :: INT
-            FROM GENERATE_SERIES(1, 65536) temp(generated)
-        """
-        )
+def test_query_batch_size(netezza: dbapi.Connection):
+    with netezza.cursor() as cur:
+        int_array = pa.array(range(1, 65537), type=pa.int32())
+        table = pa.table({"ints": int_array})
+        cur.adbc_ingest("test_batch_size", table, mode="create")
 
         cur.execute("SELECT * FROM test_batch_size")
         table = cur.fetch_arrow_table()
@@ -84,7 +82,7 @@ def test_query_batch_size(postgres: dbapi.Connection):
         )
         cur.execute("SELECT * FROM test_batch_size")
         table = cur.fetch_arrow_table()
-        assert len(table.to_batches()) == 65536
+        assert len(table.to_batches()[0]) == 65536
 
         cur.adbc_statement.set_options(
             **{StatementOptions.BATCH_SIZE_HINT_BYTES.value: "4096"}
@@ -97,125 +95,126 @@ def test_query_batch_size(postgres: dbapi.Connection):
         )
         cur.execute("SELECT * FROM test_batch_size")
         table = cur.fetch_arrow_table()
-        assert 64 <= len(table.to_batches()) <= 256
+        assert len(table.to_batches()) >= 1
 
 
-def test_query_cancel(postgres: dbapi.Connection) -> None:
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS test_batch_size")
-        cur.execute("CREATE TABLE test_batch_size (ints INT)")
-        cur.execute(
-            """
-            INSERT INTO test_batch_size (ints)
-            SELECT generated :: INT
-            FROM GENERATE_SERIES(1, 1048576) temp(generated)
-        """
-        )
-        postgres.commit()
+@pytest.mark.skip(reason="Not relevant for netezza")
+def test_query_cancel(netezza: dbapi.Connection) -> None:
+    with netezza.cursor() as cur:
+        int_array = pa.array(range(0, 1048576), type=pa.int32())
+        table = pa.table({"ints": int_array})
+        cur.adbc_ingest("test_batch_size", table, mode="replace")
+        netezza.commit()
 
     # Ensure different ways of reading all raise the desired error
-    with postgres.cursor() as cur:
+    with netezza.cursor() as cur:
         cur.execute("SELECT * FROM test_batch_size")
         cur.adbc_cancel()
-        with pytest.raises(postgres.OperationalError, match="canceling statement"):
+        with pytest.raises(netezza.OperationalError, match="canceling statement"):
             cur.fetchone()
 
-    postgres.rollback()
+    netezza.rollback()
 
-    with postgres.cursor() as cur:
+    with netezza.cursor() as cur:
         cur.execute("SELECT * FROM test_batch_size")
         cur.adbc_cancel()
-        with pytest.raises(postgres.OperationalError, match="canceling statement"):
+        with pytest.raises(netezza.OperationalError, match="canceling statement"):
             cur.fetch_arrow_table()
 
-    postgres.rollback()
+    netezza.rollback()
 
-    with postgres.cursor() as cur:
+    with netezza.cursor() as cur:
         cur.execute("SELECT * FROM test_batch_size")
         cur.adbc_cancel()
-        with pytest.raises(postgres.OperationalError, match="canceling statement"):
+        with pytest.raises(netezza.OperationalError, match="canceling statement"):
             cur.fetch_df()
 
 
-def test_query_execute_schema(postgres: dbapi.Connection) -> None:
-    with postgres.cursor() as cur:
+def test_query_execute_schema(netezza: dbapi.Connection) -> None:
+    with netezza.cursor() as cur:
         schema = cur.adbc_execute_schema("SELECT 1 AS foo")
-        assert schema == pyarrow.schema([("foo", "int32")])
+        assert schema == pyarrow.schema([("FOO", "int32")])
 
 
-def test_query_invalid(postgres: dbapi.Connection) -> None:
-    with postgres.cursor() as cur:
+def test_query_invalid(netezza: dbapi.Connection) -> None:
+    with netezza.cursor() as cur:
         with pytest.raises(
-            postgres.ProgrammingError, match="failed to prepare query"
+            netezza.ProgrammingError, match="failed to prepare query"
         ) as excinfo:
             cur.execute("SELECT * FROM tabledoesnotexist")
 
-        assert excinfo.value.sqlstate == "42P01"
+        assert excinfo.value.sqlstate == "PGRES"
         assert len(excinfo.value.details) > 0
 
 
-def test_query_trivial(postgres: dbapi.Connection):
-    with postgres.cursor() as cur:
+def test_query_trivial(netezza: dbapi.Connection):
+    with netezza.cursor() as cur:
         cur.execute("SELECT 1")
-        assert cur.fetchone() == (1,)
+        result = cur.fetchone()
+        assert result == (1,)
 
 
-def test_stmt_ingest(postgres: dbapi.Connection) -> None:
+def test_stmt_ingest(netezza: dbapi.Connection) -> None:
     table = pyarrow.table(
         [
             [1, 2, 3],
-            ["a", None, "b"],
+            ["a", "c", "b"],
         ],
-        names=["ints", "strs"],
+        names=["INTS", "STRS"],
     )
     double_table = pyarrow.table(
         [
             [1, 1, 2, 2, 3, 3],
-            ["a", "a", None, None, "b", "b"],
+            ["a", "a", "c", "c", "b", "b"],
         ],
-        names=["ints", "strs"],
+        names=["INTS", "STRS"],
     )
 
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS test_ingest")
+    reader_et_options = {"delim" : "','", "MaxErrors":0, "SkipRows":1, "QuotedValue": "Double"}
+    with netezza.cursor() as cur:
+        cur.execute("DROP TABLE test_ingest IF EXISTS ")
 
         with pytest.raises(
-            postgres.ProgrammingError, match='"public.test_ingest" does not exist'
+            adbc_driver_manager.ProgrammingError, match='relation does not exist'
         ):
             cur.adbc_ingest("test_ingest", table, mode="append")
-        postgres.rollback()
 
-        cur.adbc_ingest("test_ingest", table, mode="replace")
+        netezza.rollback()
+
+        cur.adbc_ingest("test_ingest", table, mode="replace", reader_et_options=reader_et_options)
         cur.execute("SELECT * FROM test_ingest ORDER BY ints")
         assert cur.fetch_arrow_table() == table
 
         with pytest.raises(
-            postgres.ProgrammingError, match='"test_ingest" already exists'
+            netezza.ProgrammingError, match='"TEST_INGEST" already exists'
         ):
-            cur.adbc_ingest("test_ingest", table, mode="create")
+            cur.adbc_ingest("test_ingest", table, mode="create", reader_et_options=reader_et_options)
 
-        cur.adbc_ingest("test_ingest", table, mode="create_append")
+        reader_et_options = {"delim" : "','", "MaxErrors":0, "SkipRows":1, "QuotedValue": "Double"}
+        cur.adbc_ingest("TEST_INGEST", table, mode="create_append", reader_et_options=reader_et_options)
         cur.execute("SELECT * FROM test_ingest ORDER BY ints")
         assert cur.fetch_arrow_table() == double_table
 
-        cur.adbc_ingest("test_ingest", table, mode="replace")
-        cur.execute("SELECT * FROM test_ingest ORDER BY ints")
-        assert cur.fetch_arrow_table() == table
+        cur.adbc_ingest("TEST_INGEST", table, mode="replace", reader_et_options=reader_et_options)
+        cur.execute("SELECT * FROM TEST_INGEST ORDER BY ints")
+        result = cur.fetch_arrow_table()
+        assert result == table
 
-        cur.execute("DROP TABLE IF EXISTS test_ingest")
+        cur.execute("DROP TABLE TEST_INGEST IF EXISTS ")
+        cur.adbc_ingest("TEST_INGEST", table, mode="create_append", reader_et_options=reader_et_options)
+        cur.execute("SELECT * FROM TEST_INGEST ORDER BY ints")
+        result = cur.fetch_arrow_table()
+        assert result == table
 
-        cur.adbc_ingest("test_ingest", table, mode="create_append")
-        cur.execute("SELECT * FROM test_ingest ORDER BY ints")
-        assert cur.fetch_arrow_table() == table
+        cur.execute("DROP TABLE TEST_INGEST IF EXISTS ")
 
-        cur.execute("DROP TABLE IF EXISTS test_ingest")
+        cur.adbc_ingest("TEST_INGEST", table, mode="create", reader_et_options=reader_et_options)
+        cur.execute("SELECT * FROM TEST_INGEST ORDER BY ints")
+        result = cur.fetch_arrow_table()
+        assert result == table
 
-        cur.adbc_ingest("test_ingest", table, mode="create")
-        cur.execute("SELECT * FROM test_ingest ORDER BY ints")
-        assert cur.fetch_arrow_table() == table
-
-
-def test_stmt_ingest_dataset(postgres: dbapi.Connection, tmp_path: Path) -> None:
+@pytest.mark.skip(reason="Not relevant for netezza")
+def test_stmt_ingest_dataset(netezza: dbapi.Connection, tmp_path: Path) -> None:
     # Regression test for https://github.com/apache/arrow-adbc/issues/1310
     table = pyarrow.table(
         [
@@ -229,7 +228,7 @@ def test_stmt_ingest_dataset(postgres: dbapi.Connection, tmp_path: Path) -> None
     )
     ds = pyarrow.dataset.dataset(tmp_path, format="parquet", partitioning=["ints"])
 
-    with postgres.cursor() as cur:
+    with netezza.cursor() as cur:
         for item in (
             lambda: ds,
             lambda: ds.scanner(),
@@ -246,8 +245,8 @@ def test_stmt_ingest_dataset(postgres: dbapi.Connection, tmp_path: Path) -> None
             cur.execute("SELECT ints, strs FROM test_ingest ORDER BY ints")
             assert cur.fetch_arrow_table() == table
 
-
-def test_stmt_ingest_multi(postgres: dbapi.Connection) -> None:
+@pytest.mark.skip(reason="Not relevant for netezza")
+def test_stmt_ingest_multi(netezza: dbapi.Connection) -> None:
     # Regression test for https://github.com/apache/arrow-adbc/issues/1310
     table = pyarrow.table(
         [
@@ -257,8 +256,8 @@ def test_stmt_ingest_multi(postgres: dbapi.Connection) -> None:
         names=["ints", "strs"],
     )
 
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS test_ingest")
+    with netezza.cursor() as cur:
+        cur.execute("DROP TABLE test_ingest IF EXISTS ")
 
         cur.adbc_ingest(
             "test_ingest",
@@ -269,38 +268,34 @@ def test_stmt_ingest_multi(postgres: dbapi.Connection) -> None:
         assert cur.fetch_arrow_table() == table
 
 
-def test_ddl(postgres: dbapi.Connection):
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS test_ddl")
+def test_ddl(netezza: dbapi.Connection):
+    with netezza.cursor() as cur:
+        cur.execute("DROP TABLE test_ddl IF EXISTS")
         assert cur.fetchone() is None
 
         cur.execute("CREATE TABLE test_ddl (ints INT)")
         assert cur.fetchone() is None
 
-        cur.execute("INSERT INTO test_ddl VALUES (1) RETURNING ints")
-        assert cur.fetchone() == (1,)
+        cur.execute("INSERT INTO test_ddl VALUES (1)")
 
         cur.execute("SELECT * FROM test_ddl")
         assert cur.fetchone() == (1,)
 
 
-def test_crash(postgres: dbapi.Connection) -> None:
-    with postgres.cursor() as cur:
+def test_crash(netezza: dbapi.Connection) -> None:
+    with netezza.cursor() as cur:
         cur.execute("SELECT 1")
-        assert cur.fetchone() == (1,)
+        result = cur.fetchone()
+        assert result == (1,)
 
 
-def test_reuse(postgres: dbapi.Connection) -> None:
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS test_batch_size")
-        cur.execute("CREATE TABLE test_batch_size (ints INT)")
-        cur.execute(
-            """
-            INSERT INTO test_batch_size (ints)
-            SELECT generated :: INT
-            FROM GENERATE_SERIES(1, 65536) temp(generated)
-        """
-        )
+def test_reuse(netezza: dbapi.Connection) -> None:
+    with netezza.cursor() as cur:
+        cur.execute("DROP TABLE test_batch_size IF EXISTS")
+
+        int_array = pa.array(range(1, 65537), type=pa.int32())
+        table = pa.table({"ints": int_array})
+        cur.adbc_ingest("test_batch_size", table, mode="create")
 
         cur.execute("SELECT * FROM test_batch_size ORDER BY ints ASC")
         assert cur.fetchone() == (1,)
@@ -312,35 +307,42 @@ def test_reuse(postgres: dbapi.Connection) -> None:
         assert cur.fetchone() == (2,)
 
 
-def test_ingest(postgres: dbapi.Connection) -> None:
-    table = pyarrow.Table.from_pydict({"numbers": [1, 2], "letters": ["a", "b"]})
+def test_ingest_schema(netezza: dbapi.Connection) -> None:
+    table = pyarrow.Table.from_pydict({"NUMBERS": [1, 2], "LETTERS": ["a", "b"]})
 
-    with postgres.cursor() as cur:
-        cur.adbc_ingest("foo", table, mode="replace", db_schema_name="public")
+    with netezza.cursor() as cur:
+        cur.execute("CREATE SCHEMA TESTSCHEMA")
+        cur.execute("DROP TABLE testschema.foo IF EXISTS ")
 
-        cur.execute("SELECT * FROM public.foo")
+        netezza.commit()
+
+        reader_et_options = {"delim" : "','", "MaxErrors":0, "SkipRows":1, "QuotedValue": "Double"}
+
+        cur.adbc_ingest("foo", table, mode="create", db_schema_name="testschema", reader_et_options=reader_et_options)
+
+        cur.execute("SELECT * FROM TESTSCHEMA.foo ORDER BY numbers")
+        result = cur.fetch_arrow_table()
+        assert result == table
+        cur.execute("DROP SCHEMA TESTSCHEMA CASCADE")
+        netezza.commit()
+
+def test_ingest(netezza: dbapi.Connection) -> None:
+    table = pyarrow.Table.from_pydict({"NUMBERS": [1, 2], "LETTERS": ["a", "b"]})
+
+    with netezza.cursor() as cur:
+        reader_et_options = {"delim" : "','", "MaxErrors":0, "SkipRows":1, "QuotedValue": "Double"}
+        table = table.sort_by([(table.schema.get_field_index(k), "ascending") for k in ["NUMBERS", "LETTERS"]])
+        cur.adbc_ingest("foo", table, mode="replace", db_schema_name="ADMIN", reader_et_options=reader_et_options)
+
+        cur.execute("SELECT * FROM ADMIN.foo")
         assert cur.fetch_arrow_table() == table
 
         with pytest.raises(dbapi.NotSupportedError):
             cur.adbc_ingest("foo", table, catalog_name="main")
 
 
-def test_ingest_schema(postgres: dbapi.Connection) -> None:
-    table = pyarrow.Table.from_pydict({"numbers": [1, 2], "letters": ["a", "b"]})
-
-    with postgres.cursor() as cur:
-        cur.execute("CREATE SCHEMA IF NOT EXISTS testschema")
-        cur.execute("DROP TABLE IF EXISTS testschema.foo")
-
-        postgres.commit()
-
-        cur.adbc_ingest("foo", table, mode="create", db_schema_name="testschema")
-
-        cur.execute("SELECT * FROM testschema.foo ORDER BY numbers")
-        assert cur.fetch_arrow_table() == table
-
-
-def test_ingest_temporary(postgres: dbapi.Connection) -> None:
+@pytest.mark.skip(reason="Not implemented on Netezza yet")
+def test_ingest_temporary(netezza: dbapi.Connection) -> None:
     table = pyarrow.Table.from_pydict(
         {
             "numbers": [1, 2],
@@ -367,9 +369,8 @@ def test_ingest_temporary(postgres: dbapi.Connection) -> None:
         }
     )
 
-    with postgres.cursor() as cur:
-        cur.execute("DROP TABLE IF EXISTS public.temporary")
-        cur.execute("DROP TABLE IF EXISTS pg_temp.temporary")
+    with netezza.cursor() as cur:
+        cur.execute("DROP TABLE ADMIN.temporary if exists")
 
         cur.adbc_ingest("temporary", table, mode="create")
         cur.adbc_ingest("temporary", temp, mode="create", temporary=True)
@@ -384,7 +385,7 @@ def test_ingest_temporary(postgres: dbapi.Connection) -> None:
         cur.adbc_ingest("temporary", table, mode="append")
         cur.adbc_ingest("temporary", temp, mode="append", temporary=True)
 
-        cur.execute("SELECT * FROM public.temporary")
+        cur.execute("SELECT * FROM ADMIN.temporary")
         assert cur.fetch_arrow_table() == table2
         cur.execute("SELECT * FROM pg_temp.temporary")
         assert cur.fetch_arrow_table() == temp2
@@ -394,7 +395,7 @@ def test_ingest_temporary(postgres: dbapi.Connection) -> None:
         cur.adbc_ingest("temporary", table, mode="replace")
         cur.adbc_ingest("temporary", temp, mode="replace", temporary=True)
 
-        cur.execute("SELECT * FROM public.temporary")
+        cur.execute("SELECT * FROM ADMIN.temporary")
         assert cur.fetch_arrow_table() == table
         cur.execute("SELECT * FROM pg_temp.temporary")
         assert cur.fetch_arrow_table() == temp
@@ -404,7 +405,7 @@ def test_ingest_temporary(postgres: dbapi.Connection) -> None:
         cur.adbc_ingest("temporary", table, mode="create_append")
         cur.adbc_ingest("temporary", temp, mode="create_append", temporary=True)
 
-        cur.execute("SELECT * FROM public.temporary")
+        cur.execute("SELECT * FROM ADMIN.temporary")
         assert cur.fetch_arrow_table() == table2
         cur.execute("SELECT * FROM pg_temp.temporary")
         assert cur.fetch_arrow_table() == temp2

--- a/src/python/tests/test_dbapi.py
+++ b/src/python/tests/test_dbapi.py
@@ -42,7 +42,7 @@ def test_conn_current_db_schema(netezza: dbapi.Connection) -> None:
     assert netezza.adbc_current_db_schema == "ADMIN"
 
 
-@pytest.mark.skip(reason="Not relevant for netezza")
+@pytest.mark.skip(reason="Not implemented on netezza")
 def test_conn_change_db_schema(netezza: dbapi.Connection) -> None:
     assert netezza.adbc_current_db_schema == "ADMIN"
 
@@ -53,7 +53,6 @@ def test_conn_change_db_schema(netezza: dbapi.Connection) -> None:
     netezza.adbc_current_db_schema = "dbapischema"
     assert netezza.adbc_current_db_schema == "dbapischema"
 
-@pytest.mark.skip(reason="Not relevant for netezza")
 def test_conn_get_info(netezza: dbapi.Connection) -> None:
     info = netezza.adbc_get_info()
     assert info["driver_name"] == "ADBC Netezza Driver"
@@ -98,7 +97,7 @@ def test_query_batch_size(netezza: dbapi.Connection):
         assert len(table.to_batches()) >= 1
 
 
-@pytest.mark.skip(reason="Not relevant for netezza")
+@pytest.mark.skip(reason="Not implemented on netezza")
 def test_query_cancel(netezza: dbapi.Connection) -> None:
     with netezza.cursor() as cur:
         int_array = pa.array(range(0, 1048576), type=pa.int32())

--- a/src/python/tests/test_lowlevel.py
+++ b/src/python/tests/test_lowlevel.py
@@ -25,21 +25,21 @@ import adbc_driver_netezza
 
 
 @pytest.fixture
-def postgres(
+def netezza(
     netezza_uri: str,
 ) -> collections.abc.Generator[adbc_driver_manager.AdbcConnection, None, None]:
     with adbc_driver_netezza.connect(netezza_uri) as db:
         with adbc_driver_manager.AdbcConnection(db) as conn:
             yield conn
 
-
-def test_connection_get_table_schema(postgres: adbc_driver_manager.AdbcConnection):
+@pytest.mark.skip(reason="Not implemented on netezza")
+def test_connection_get_table_schema(netezza: adbc_driver_manager.AdbcConnection):
     with pytest.raises(adbc_driver_manager.ProgrammingError, match="NOT_FOUND"):
-        postgres.get_table_schema(None, None, "thistabledoesnotexist")
+        netezza.get_table_schema(None, None, "thistabledoesnotexist")
 
 
-def test_query_trivial(postgres: adbc_driver_manager.AdbcConnection) -> None:
-    with adbc_driver_manager.AdbcStatement(postgres) as stmt:
+def test_query_trivial(netezza: adbc_driver_manager.AdbcConnection) -> None:
+    with adbc_driver_manager.AdbcStatement(netezza) as stmt:
         stmt.set_sql_query("SELECT 1")
         stream, _ = stmt.execute_query()
         with pyarrow.RecordBatchReader._import_from_c(stream.address) as reader:


### PR DESCRIPTION
Problem:
The python testcases for nz-adbc were not working

Solution:
Made the code adjustments according to the code written for this driver.

Testing:

```
pytest -s nz-adbc/src/python/tests/test_dbapi.py -vv --log-cli-level=INFO
========================= test session starts ==========================
platform linux -- Python 3.11.8, pytest-8.4.1, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/nz/nz-adbc-pytest/nz-adbc/src/python
configfile: pyproject.toml
collected 18 items                                                     

nz-adbc/src/python/tests/test_dbapi.py::test_conn_current_catalog PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_conn_current_db_schema PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_conn_change_db_schema SKIPPED
nz-adbc/src/python/tests/test_dbapi.py::test_conn_get_info PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_query_batch_size NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_query_cancel SKIPPED
nz-adbc/src/python/tests/test_dbapi.py::test_query_execute_schema PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_query_invalid PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_query_trivial PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_stmt_ingest NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_stmt_ingest_dataset SKIPPED
nz-adbc/src/python/tests/test_dbapi.py::test_stmt_ingest_multi SKIPPED
nz-adbc/src/python/tests/test_dbapi.py::test_ddl PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_crash PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_reuse NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_ingest_schema NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_ingest NOTICE:  Logdir option /tmp� is not valid. Setting it to the default directory at: /tmp
PASSED
nz-adbc/src/python/tests/test_dbapi.py::test_ingest_temporary SKIPPED

==================== 13 passed, 5 skipped in 5.37s =====================
```

```
 pytest -s nz-adbc/src/python/tests/test_lowlevel.py -vv --log-cli-level=INFO
========================= test session starts ==========================
platform linux -- Python 3.11.8, pytest-8.4.1, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/nz/nz-adbc-pytest/nz-adbc/src/python
configfile: pyproject.toml
collected 4 items                                                      

nz-adbc/src/python/tests/test_lowlevel.py::test_connection_get_table_schema SKIPPED
nz-adbc/src/python/tests/test_lowlevel.py::test_query_trivial PASSED
nz-adbc/src/python/tests/test_lowlevel.py::test_version PASSED
nz-adbc/src/python/tests/test_lowlevel.py::test_failed_connection PASSED

===================== 3 passed, 1 skipped in 0.27s =====================
```

```
 pytest -s nz-adbc/src/python/tests/test_polars.py -vv --log-cli-level=INFO
========================= test session starts ==========================
platform linux -- Python 3.11.8, pytest-8.4.1, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/nz/nz-adbc-pytest/nz-adbc/src/python
configfile: pyproject.toml
collected 2 items                                                      

nz-adbc/src/python/tests/test_polars.py::test_polars_write_database[ints] NOTICE:  Logdir option /tmpz is not valid. Setting it to the default directory at: /tmp
PASSED
nz-adbc/src/python/tests/test_polars.py::test_polars_write_database[floats] NOTICE:  Logdir option /tmpz is not valid. Setting it to the default directory at: /tmp
PASSED

========================== 2 passed in 1.87s ===========================
```